### PR TITLE
Use https url for tinyusb git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/tinyusb"]
 	path = 3rdparty/tinyusb
-	url = git@github.com:liamfraser/tinyusb.git
+	url = https://github.com/liamfraser/tinyusb.git


### PR DESCRIPTION
You can't do an anonymous checkout of a github git repo using the git protocol. And - not everyone uses it these days anyway.
Switch to cloning over https instead.