### PR TITLE
Modernize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,10 @@ cmake_minimum_required(VERSION 3.13)
 if (PICO_SDK_PATH)
     include(pico_sdk_import.cmake)
     include(pico_extras_import.cmake)
+    set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR}/src/pico/boards)
 endif()
 
-project("Chocolate Doom" VERSION 3.0.0 LANGUAGES C CXX)
+project("RP2040 Doom" VERSION 3.0.0 LANGUAGES C CXX)
 enable_language(CXX)
 set(CMAKE_CXX_STANDARD 14)
 

--- a/pico_extras_import.cmake
+++ b/pico_extras_import.cmake
@@ -26,14 +26,14 @@ if (NOT PICO_EXTRAS_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_EXTRAS_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
         FetchContent_Declare(
-                PICO_EXTRAS
+                pico_extras
                 GIT_REPOSITORY https://github.com/raspberrypi/pico-extras
                 GIT_TAG master
         )
-        if (NOT PICO_EXTRAS)
-            message("Downloading PICO EXTRAS")
-            FetchContent_Populate(PICO_EXTRAS)
-            set(PICO_EXTRAS_PATH ${PICO_EXTRAS_SOURCE_DIR})
+        if (NOT pico_extras)
+            message("Downloading Raspberry Pi Pico Extras")
+            FetchContent_Populate(pico_extras)
+            set(PICO_EXTRAS_PATH ${pico_extras_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
     else ()

--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -3,8 +3,6 @@
 # This can be dropped into an external project to help locate this SDK
 # It should be include()ed prior to project()
 
-# todo document
-
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
@@ -20,8 +18,8 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_P
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
-set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the PICO SDK")
-set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of PICO SDK from git if not otherwise locatable")
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
 set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
 
 if (NOT PICO_SDK_PATH)
@@ -31,20 +29,31 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        FetchContent_Declare(
-                pico_sdk
-                GIT_REPOSITORY git@asic-git.pitowers.org:projectmu/pico_sdk.git
-                GIT_TAG master
-        )
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+            )
+        endif ()
+
         if (NOT pico_sdk)
-            message("Downloading PICO SDK")
+            message("Downloading Raspberry Pi Pico SDK")
             FetchContent_Populate(pico_sdk)
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
     else ()
         message(FATAL_ERROR
-                "PICO SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
                 )
     endif ()
 endif ()
@@ -56,9 +65,9 @@ endif ()
 
 set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
 if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
-    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the PICO SDK")
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
 endif ()
 
-set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the PICO SDK" FORCE)
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
 
 include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -82,7 +82,7 @@
 #if PICO_BUILD
 #include "i_picosound.h"
 #if USB_SUPPORT
-#include "tusb.h"
+#include "host/usbh.h"
 #endif
 #endif
 //

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -31,6 +31,7 @@
 #include "pico/multicore.h"
 #if PICO_ON_DEVICE
 #include "hardware/vreg.h"
+#include "hardware/clocks.h"
 #endif
 #endif
 #if USE_PICO_NET
@@ -62,8 +63,15 @@ int main(int argc, char **argv)
 #endif
 #if PICO_ON_DEVICE
     vreg_set_voltage(VREG_VOLTAGE_1_30);
-    // todo pause? is this the cause of the cold start isue?
-    set_sys_clock_khz(270000, true);
+#define PLL 270000
+    set_sys_clock_khz(PLL, true);
+    clock_configure(
+            clk_peri,
+            0,                                                // No glitchless mux
+            CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS, // System PLL on AUX mux
+            PLL*1000,                               // Input frequency
+            PLL*1000                                // Output (must be same as no divider)
+        );
 #if !USE_PICO_NET
     // debug ?
 //    gpio_debug_pins_init();

--- a/src/pico/i_input.c
+++ b/src/pico/i_input.c
@@ -36,6 +36,7 @@
 #if USB_SUPPORT
 #include "pico/binary_info.h"
 #include "tusb.h"
+#include "host/usbh.h"
 #include "hardware/irq.h"
 bi_decl(bi_program_feature("USB keyboard support"));
 #endif

--- a/src/pico/i_system.c
+++ b/src/pico/i_system.c
@@ -24,7 +24,7 @@
 #include "doom/p_saveg.h"
 #endif
 #if USB_SUPPORT
-#include "tusb.h"
+#include "host/usbh.h"
 #endif
 extern void I_InputInit();
 


### PR DESCRIPTION
1. Allocate user IRQ to avoid conflict / hard fault when other parts are changed and/or SDK features included.
2. Use `*.cmake` from SDK 1.5.1.
3. Allow for in-tree board definitions.
4. A distinctive CMake project name for IDE.
5. Include `host/usbh.h` instead of `tusb.h` where the former could be ifdef-ed out depending on the config. I believe this is a proper semantic / intention.
6. Overclocking now preserves correct peripherals clock (SPI).
7. Invoke `irq_set_pending()` every core1 loop. While invoking once is sufficient when all is going well, I see better stability when things go wrong. It's a cheap insurance that has no bad side effects.
8. I've experimented with `sleep_ms()` between `vreg_set_voltage()` and `set_sys_clock_khz()` and it did not resolve cold-start issue. TODO removed.