### PR TITLE
Fix compilation error on Ubuntu 22.04 LTS

### DIFF
--- a/src/whd_gen/statsomizer.h
+++ b/src/whd_gen/statsomizer.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <string>
 #include <algorithm>
+#include <limits>
 
 struct statsomizer {
     const std::string name;


### PR DESCRIPTION
Add missing header file to prevent compilation error.

```
In file included from /home/exl/Downloads/rp2040-doom/src/pd_render.cpp:71:
/home/exl/Downloads/rp2040-doom/src/pico/../whd_gen/statsomizer.h: In member function ‘void statsomizer::reset()’:
/home/exl/Downloads/rp2040-doom/src/pico/../whd_gen/statsomizer.h:36:20: error: ‘numeric_limits’ is not a member of ‘std’
   36 |         min = std::numeric_limits<int>::max();
      |                    ^~~~~~~~~~~~~~
/home/exl/Downloads/rp2040-doom/src/pico/../whd_gen/statsomizer.h:36:35: error: expected primary-expression before ‘int’
   36 |         min = std::numeric_limits<int>::max();
      |                                   ^~~
/home/exl/Downloads/rp2040-doom/src/pico/../whd_gen/statsomizer.h:37:20: error: ‘numeric_limits’ is not a member of ‘std’
   37 |         max = std::numeric_limits<int>::min();
      |                    ^~~~~~~~~~~~~~
/home/exl/Downloads/rp2040-doom/src/pico/../whd_gen/statsomizer.h:37:35: error: expected primary-expression before ‘int’
   37 |         max = std::numeric_limits<int>::min();
      |                                   ^~~
make[2]: *** [src/CMakeFiles/doom_tiny.dir/build.make:1938: src/CMakeFiles/doom_tiny.dir/pd_render.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:978: src/CMakeFiles/doom_tiny.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```